### PR TITLE
Try to cleanly unmount docker block devices

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4302,9 +4302,10 @@ func TestBuildWithTabs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `["/bin/sh","-c","echo\tone\t\ttwo"]`
-	if res != expected {
-		t.Fatalf("Missing tabs.\nGot:%s\nExp:%s", res, expected)
+	expected1 := `["/bin/sh","-c","echo\tone\t\ttwo"]`
+	expected2 := `["/bin/sh","-c","echo\u0009one\u0009\u0009two"]` // syntactically equivalent, and what Go 1.3 generates
+	if res != expected1 && res != expected2 {
+		t.Fatalf("Missing tabs.\nGot: %s\nExp: %s or %s", res, expected1, expected2)
 	}
 	logDone("build - with tabs")
 }


### PR DESCRIPTION
In an attempt to _improve_ the situation with #5684 this change tries to clean up those block devices. Docker _very_ frequently leaves block devices behind if the running containers are not stopped prior to stopping the daemon resulting in the service not starting correctly.

Containers with restart policies set to "always" are not able to start as a result of this. This change tries to unmount devices left by the service after the service is stopped. If the community doesn't like this solution, another possible solution would be to stop all containers using `docker stop $(docker ps -aq)` _before_ the daemon is stopped which should work pretty well as well.
